### PR TITLE
wezterm: use file_path to avoid issue on path

### DIFF
--- a/.config/wezterm/open-in-nvim.lua
+++ b/.config/wezterm/open-in-nvim.lua
@@ -72,11 +72,7 @@ local function extract_filename(uri)
 end
 
 local function get_pwd(pane)
-	-- Url object
-	local pwd_url = pane:get_current_working_dir()
-	local pwd = tostring(pwd_url)
-	pwd = pwd:gsub("^file://", "")
-	return pwd
+  return pane:get_current_working_dir().file_path
 end
 
 local function extract_line_and_name(uri)


### PR DESCRIPTION
On MACOS the pane:get_current_working_dir() contains the host:

'file://myhost/some/path%20with%20spaces'

According to https://wezfurlong.org/wezterm/config/lua/wezterm.url/Url.html we should use file_path.